### PR TITLE
Update README

### DIFF
--- a/anyio/README
+++ b/anyio/README
@@ -3,12 +3,20 @@ The latest version of this anyio package can always be obtained from:
 https://github.com/whaleygeek/anyio
 
 
-The ProMicro.inf in the anyio/firmware folder originally came from
+The ProMicro.inf in the anyio/arduino/firmware folder originally came from
 the sparkfun github repository, and is included here for convenience
-only. You can always get the latest version from here:
+only. The latest version was available from here:
 
 https://github.com/sparkfun/SF32u4_boards/blob/master/driver/ProMicro.inf
 
+However this is no longer available, see here:
+
+https://github.com/sparkfun/SF32u4_boards
+
+The referenced Arduino Boards repository also no longer includes the file. 
+See here:
+
+https://github.com/sparkfun/Arduino_Boards
 
 @whaleygeek
 David Whale


### PR DESCRIPTION
The ProMicro.inf file is no longer in the reference Sparkfun repository. The folder referenced in the Anyio repository is no longer correct either. Adjustments made.